### PR TITLE
Set external settings icon tint mode to SRC_ATOP

### DIFF
--- a/src/com/android/settings/dashboard/DashboardAdapter.java
+++ b/src/com/android/settings/dashboard/DashboardAdapter.java
@@ -20,6 +20,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.Icon;
+import android.graphics.PorterDuff.Mode;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.support.v7.widget.PopupMenu;
@@ -150,7 +151,7 @@ public class DashboardAdapter extends RecyclerView.Adapter<DashboardAdapter.Dash
                         mContext.getTheme().resolveAttribute(tintColorValue.data,
                                 tintColorValue, true);
                     }
-                    tile.icon.setTint(tintColorValue.data);
+                    tile.icon.setTint(tintColorValue.data).setTintMode(Mode.SRC_ATOP);
                 }
             }
         }


### PR DESCRIPTION
With "Expose color for external settings icons" commit, themers can change
the color of the external settings icon to whatever they want except
transparent. When they set the tint color to transparent the icon will be
dissapeared, this commits fixed the problem by changing the tint mode.

Before: http://i.imgur.com/ghDPs27.jpg
After: http://i.imgur.com/AUEFgNO.jpg

Change-Id: I65b710e2abefd1052b3af154a98247de9b4fe98d